### PR TITLE
dispose canvas if getImageData throws an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,15 @@ module.exports = function(image, opts) {
     canvas.height = opts.height
     context.clearRect(0,0,opts.width,opts.height)
     context.drawImage(image, opts.x, opts.y, opts.width, opts.height, 0, 0, opts.width, opts.height)
-    var imgData = context.getImageData(0, 0, opts.width, opts.height)
+
+    var imgData
+    try {
+        imgData = context.getImageData(0, 0, opts.width, opts.height)
+    } catch(e){
+        module.exports.dispose()
+        throw e
+    }
+
     return imgData.data
 }
 


### PR DESCRIPTION
If `getImageData` throws an error, such as when it has been "tainted by cross-origin data" the module will continue to throw the same error for any successive calls. This pull request disposes the current canvas when an error has occurred.
